### PR TITLE
Add mypy type checking and fix all type errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ debug.txt
 .vscode
 .DS_Store
 .idea
+.mypy_cache

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Python 3 implementation of a z-machine interpreter, for playing Infocom games. To play a z-machine file:
 
-`python zmachine [GAME_FILE]`
+`python -m zmachine [GAME_FILE]`
 
 The interpreter supports z-machine versions 3, 4 and 5. Version 4 games include Trinity, AMFV, and Bureaucracy. Version 5 games include Border Zone and Beyond Zork. Save files are in [Quetzal](http://inform-fiction.org/zmachine/standards/quetzal/index.html) format and should be compatible with the Frotz interpreter.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.mypy]
+python_version = "3.12"
+warn_return_any = true
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+no_implicit_optional = true
+strict_equality = true
+
+# Start with these disabled, can enable incrementally
+disallow_untyped_defs = false
+disallow_any_generics = false
+disallow_subclassing_any = false
+
+# These are helpful
+check_untyped_defs = true
+warn_unreachable = true
+
+# Tell mypy that zmachine is a namespace package with implicit imports
+namespace_packages = true
+explicit_package_bases = true
+mypy_path = "."
+
+# Ignore missing imports for libraries without stubs
+[[tool.mypy.overrides]]
+module = "curses"
+ignore_missing_imports = true

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,4 +1,4 @@
-from screen_test import ScreenTest
+from .screen_test import ScreenTest
 
 
 def main():

--- a/tests/screen_test.py
+++ b/tests/screen_test.py
@@ -1,19 +1,22 @@
 from zmachine.screen import ScreenV4
-from zmachine.__curses import CursesAdapter
+from zmachine.config import ZMachineConfig
+from zmachine.curses import CursesAdapter
 from zmachine.output import ScreenStream
-from zmachine.event import EventArgs
+from zmachine.enums import TextStyle, WindowPosition
+from zmachine.event import EventManager, EventArgs
 
 
 class ScreenTest:
     def __init__(self, version: int):
         self.version = version
-        self.adapter = CursesAdapter()
-        self.screen = ScreenV4(self.adapter)
+        config = ZMachineConfig(game_file = '',version = version)
+        self.event_manager = EventManager()
+        self.adapter = CursesAdapter(config)
+        self.screen = ScreenV4(self.adapter, self.event_manager)
         self.stream = ScreenStream(self.screen)
         self.stream.buffer_mode = True
         self.height = self.adapter.height
         self.width = self.adapter.width
-        self.event_manager = self.stream.event_manager
         self.init_status_line()
         self.post_init()
 
@@ -57,13 +60,12 @@ class ScreenTest:
 
     def write_message(self, message):
         self.set_window(0)
-        self.stream.buffer_mode = True
         self.event_manager.pre_read_input.invoke(self, EventArgs())
         self.stream.write(f"{message} (press any key)...", True)
         self.read_char()
 
-    def read_char(self):
-        self.adapter.get_input_char()
+    def read_char(self, echo=False):
+        self.adapter.get_input_char(echo=echo)
 
     def set_text_style(self, style):
         self.event_manager.set_text_style.invoke(self, EventArgs(style=style))
@@ -84,7 +86,7 @@ class ScreenTest:
         self.set_text_style(0)
         self.stream.write(" ", False)
         for y in range(3, 6):
-            self.set_text_style(1)
+            self.set_text_style(TextStyle.REVERSE)
             self.set_cursor(y, 1)
             self.stream.write("  " * menu_width, False)
         for i in range(4):
@@ -104,11 +106,15 @@ class ScreenTest:
         self.write_message("Menu test complete, should see selected menu items in lower window")
 
     def exit_menu(self):
-        self.erase_window(1)
+        self.erase_window(WindowPosition.UPPER)
         self.split_window(1)
         self.write_to_status_line("Upper window line 1", 1, 3)
 
     def set_window(self, window_id):
+        if window_id == WindowPosition.UPPER:
+            self.stream.buffer_mode = False
+        else:
+            self.stream.buffer_mode = True
         self.event_manager.set_window.invoke(self, EventArgs(window_id=window_id))
 
     def set_cursor(self, y, x):
@@ -148,8 +154,8 @@ In one long bloody thread, from tail to snout.
             self.write_message("Can't test overlay, window is too narrow")
             return
         self.split_window(8)
-        self.set_window(1)
-        self.set_text_style(1)
+        self.set_window(WindowPosition.UPPER)
+        self.set_text_style(TextStyle.REVERSE)
         x_pos = (self.width - overlay_width) // 2
         y_pos = 4
         for line in text.split("\n"):
@@ -161,7 +167,7 @@ In one long bloody thread, from tail to snout.
             y_pos += 1
         self.split_window(1)
         self.write_to_status_line("Upper window line 1", 1)
-        self.set_window(0)
+        self.set_window(WindowPosition.LOWER)
         self.write_message("Should see overlay with lower window text preserved")
 
     def test_erase_window(self):

--- a/zmachine/__main__.py
+++ b/zmachine/__main__.py
@@ -1,5 +1,5 @@
 import sys
-from builder import ZMachineBuilder
+from .builder import ZMachineBuilder
 
 
 def main():

--- a/zmachine/abstract_interpreter.py
+++ b/zmachine/abstract_interpreter.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Tuple
-from object_table import ObjectTable
-from enums import RoutineType
+from .object_table import ObjectTable
+from .enums import RoutineType
 
 
 class AbstractZMachineInterpreter(ABC):

--- a/zmachine/builder.py
+++ b/zmachine/builder.py
@@ -1,13 +1,13 @@
-from screen import *
-from __curses import CursesAdapter
-from memory import MemoryMap
-from event import EventManager
-from input import InputStreamManager
-from output import OutputStreamManager
-from hotkey import HotkeyManager
-from interpreter import ZMachineInterpreter
-from config import ZMachineConfig
-from constants import INTERPRETER_NUMBER, INTERPRETER_REVISION
+from .screen import *
+from .curses import CursesAdapter
+from .memory import MemoryMap
+from .event import EventManager
+from .input import InputStreamManager
+from .output import OutputStreamManager
+from .hotkey import HotkeyManager
+from .interpreter import ZMachineInterpreter
+from .config import ZMachineConfig
+from .constants import INTERPRETER_NUMBER, INTERPRETER_REVISION
 
 
 class ZMachineBuilder:

--- a/zmachine/config.py
+++ b/zmachine/config.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
-from constants import SUPPORTED_VERSIONS
-from error import InvalidGameFileException
+from .constants import SUPPORTED_VERSIONS
+from .error import InvalidGameFileException
 
 @dataclass(frozen=True)
 class ZMachineConfig:
@@ -36,7 +36,7 @@ class ZMachineConfig:
     """ Length of the game file in bytes. """
     checksum: int = 0
     """ Checksum of the game file, used for copy protection. """
-    interrupt_zchars: tuple[int] = field(default_factory=tuple)
+    interrupt_zchars: tuple[int, ...] = field(default_factory=tuple[int, ...])
     """ Terminating characters (version 5 and above)"""
 
     @classmethod
@@ -61,7 +61,7 @@ class ZMachineConfig:
         abbreviation_table_addr = int.from_bytes(game_data[0x18:0x1a], "big")
         file_length = int.from_bytes(game_data[0x1a:0x1c], "big") << (1 if version <= 3 else 2)
         checksum = int.from_bytes(game_data[0x1c:0x1e], "big")
-        interrupt_zchars = []
+        interrupt_zchars: list[int] = []
         if version >= 5:
             zchars_addr = int.from_bytes(game_data[0x2e:0x30], "big")
             zchar = game_data[zchars_addr]

--- a/zmachine/config.py
+++ b/zmachine/config.py
@@ -36,7 +36,7 @@ class ZMachineConfig:
     """ Length of the game file in bytes. """
     checksum: int = 0
     """ Checksum of the game file, used for copy protection. """
-    interrupt_zchars: tuple[int, ...] = field(default_factory=tuple[int, ...])
+    interrupt_zchars: tuple[int, ...] = field(default_factory=tuple)
     """ Terminating characters (version 5 and above)"""
 
     @classmethod

--- a/zmachine/constants.py
+++ b/zmachine/constants.py
@@ -1,5 +1,5 @@
 from typing import Final
-from enums import Color
+from .enums import Color
 
 SUPPORTED_VERSIONS: Final[tuple[int, ...]] = (3, 4, 5)
 

--- a/zmachine/curses.py
+++ b/zmachine/curses.py
@@ -1,9 +1,9 @@
 import curses
 import atexit
-from screen import TerminalAdapter, Window
-from enums import TextStyle, Color
-from constants import DEFAULT_BACKGROUND_COLOR, DEFAULT_FOREGROUND_COLOR
-from config import ZMachineConfig
+from .screen import TerminalAdapter, Window
+from .enums import TextStyle, Color
+from .constants import DEFAULT_BACKGROUND_COLOR, DEFAULT_FOREGROUND_COLOR
+from .config import ZMachineConfig
 
 
 class CursesAdapter(TerminalAdapter):
@@ -28,7 +28,7 @@ class CursesAdapter(TerminalAdapter):
 
     def __init__(self, config: ZMachineConfig):
         super().__init__()
-        self.main_screen: curses.window = None
+        self.main_screen = curses.initscr()
         self.color_pairs = [[0] * 10 for _ in range(10)]
         self.color_pair_index = 1
         self.config = config
@@ -36,7 +36,6 @@ class CursesAdapter(TerminalAdapter):
         atexit.register(self.shutdown)
 
     def _initialize_curses(self):
-        self.main_screen = curses.initscr()
         curses.noecho()
         curses.cbreak()
         self.main_screen.scrollok(True)
@@ -141,8 +140,8 @@ class CursesAdapter(TerminalAdapter):
         if pair_number == 0:
             curses.init_pair(
                 self.color_pair_index,
-                self.COLORS[foreground_color],
-                self.COLORS[background_color]
+                self.COLORS[Color(foreground_color)],
+                self.COLORS[Color(background_color)]
             )
             pair_number = self.color_pair_index
             self.color_pairs[background_color][foreground_color] = pair_number
@@ -176,4 +175,3 @@ class CursesAdapter(TerminalAdapter):
             curses.endwin()
         except curses.error:
             pass # Ignore cleanup errors
-        self.main_screen = None

--- a/zmachine/hotkey.py
+++ b/zmachine/hotkey.py
@@ -1,10 +1,10 @@
 import os
 import random
 import time
-from enums import InputStreamType, OutputStreamType, Hotkey
-from event import EventManager, EventArgs
-from screen import BaseScreen
-from config import ZMachineConfig
+from .enums import InputStreamType, OutputStreamType, Hotkey
+from .event import EventManager, EventArgs
+from .screen import BaseScreen
+from .config import ZMachineConfig
 
 class HotkeyManager:
     def __init__(self, config: ZMachineConfig, screen: BaseScreen, event_manager: EventManager):
@@ -78,7 +78,7 @@ class HotkeyManager:
     def toggle_debug_mode(self) -> bool:
         event_args = EventArgs()
         self.event_manager.toggle_debug.invoke(self, event_args)
-        return event_args.debug_mode
+        return bool(event_args.debug_mode)
 
     def set_random_seed(self):
         seed = self.screen.get_input_string("Enter random seed: ", lowercase=False)
@@ -122,17 +122,17 @@ class HotkeyManager:
         """Prompt the user for a playback file and switch to the playback input stream if successful."""
         game_file = self.config.game_file
         commands = []
-        seed: int = None
+        seed: int | None = None
         in_metadata_section = True
         filepath = os.path.dirname(game_file)
         filename = os.path.basename(game_file)
         base_filename = os.path.splitext(filename)[0]
-        default_playback_file = f'{base_filename}.rec'
+        default_playback_filename = f'{base_filename}.rec'
         self.screen.write_to_screen("Enter a file name for playback.\n")
-        playback_file = self.screen.get_input_string(f"Default is {default_playback_file}: ", lowercase=False)
-        if playback_file == '':
-            playback_file = default_playback_file
-        playback_file_path = os.path.join(filepath, playback_file)
+        playback_filename = self.screen.get_input_string(f"Default is {default_playback_filename}: ", lowercase=False)
+        if playback_filename == '':
+            playback_filename = default_playback_filename
+        playback_file_path = os.path.join(filepath, playback_filename)
         if not os.path.exists(playback_file_path):
             self.screen.write_to_screen("Unable to open playback file.\n")
             return False

--- a/zmachine/input.py
+++ b/zmachine/input.py
@@ -2,11 +2,11 @@ import re
 import os
 from abc import ABC, abstractmethod
 from typing import Callable
-from enums import TerminalEscape, InputStreamType, Hotkey, WindowPosition
-from config import ZMachineConfig
-from constants import ESCAPE_CHAR
-from screen import BaseScreen, TerminalAdapter
-from event import EventManager, EventArgs
+from .enums import TerminalEscape, InputStreamType, Hotkey, WindowPosition
+from .config import ZMachineConfig
+from .constants import ESCAPE_CHAR
+from .screen import BaseScreen, TerminalAdapter
+from .event import EventManager, EventArgs
 
 class KeyboardInputParser:
     def __init__(self, terminal_adapter: TerminalAdapter):
@@ -40,7 +40,7 @@ class InputStreamManager:
         self.screen = screen
         self.keyboard_input_stream = KeyboardInputStream(screen, event_manager, config)
         self.playback_input_stream = PlaybackInputStream(screen, event_manager)
-        self.active_stream = self.keyboard_input_stream
+        self.active_stream: InputStream = self.keyboard_input_stream
         self.register_delegates(event_manager)
 
     def register_delegates(self, event_manager: EventManager):
@@ -216,11 +216,16 @@ class PlaybackInputStream(InputStream):
         else:
             # Parse format: "command text" or "command text[terminating_char]"
             matches = re.match(r'^(.+?)(?:\[(\d+)\])?$', command)
+            if matches is None:
+                self.screen.write_to_screen(f"Invalid command in playback file: {self.command_index}: {command}\n")
+                text_buffer[buffer_pos] = 13
+                self.event_manager.select_input_stream.invoke(self, EventArgs(input_stream_type=InputStreamType.KEYBOARD))
+                return
             groups = matches.groups()
             command_text = groups[0]
             if echo:
                 self.screen.write_to_screen(command_text.upper() + '\n')
-            if groups[1] is not None:
+            if len(groups) > 1 and groups[1] is not None:
                 terminating_char = int(groups[1])
                 if terminating_char == 0:
                     if interrupt_routine_caller(interrupt_routine_addr) != 0:

--- a/zmachine/interpreter.py
+++ b/zmachine/interpreter.py
@@ -1,18 +1,17 @@
 import os
-import opcodes
-from typing import Tuple
-from abstract_interpreter import AbstractZMachineInterpreter
-from config import ZMachineConfig
-from constants import INPUT_BUFFER_LENGTH
-from memory import MemoryMap
-from object_table import ObjectTable
-from event import EventArgs, EventManager
-from text import TextUtils
-from quetzal import Quetzal
-from undo import UndoStack
-from enums import WindowPosition, StatusType, RoutineType
-from stack import CallStack
-from error import *
+from . import opcodes
+from .abstract_interpreter import AbstractZMachineInterpreter
+from .config import ZMachineConfig
+from .constants import INPUT_BUFFER_LENGTH
+from .memory import MemoryMap
+from .object_table import ObjectTable
+from .event import EventArgs, EventManager
+from .text import TextUtils
+from .quetzal import Quetzal
+from .undo import UndoStack
+from .enums import WindowPosition, StatusType, RoutineType
+from .stack import CallStack, EvalStack
+from .error import *
 
 
 class ZMachineInterpreter(AbstractZMachineInterpreter):
@@ -268,16 +267,16 @@ class ZMachineInterpreter(AbstractZMachineInterpreter):
         return self.memory_map.read_word(ptr)
 
     @property
-    def eval_stack(self):
+    def eval_stack(self) -> 'EvalStack':
         return self.call_stack.eval_stack
 
     def stack_push(self, val):
         self.eval_stack.push(val)
 
-    def stack_pop(self):
+    def stack_pop(self) -> int:
         return self.eval_stack.pop()
 
-    def stack_peek(self):
+    def stack_peek(self) -> int:
         return self.eval_stack.peek()
 
     def get_global_var(self, index):
@@ -315,7 +314,7 @@ class ZMachineInterpreter(AbstractZMachineInterpreter):
         else:
             raise VariableOutOfRangeException(varnum)
 
-    def do_routine(self, call_addr: int, args: Tuple[int], routine_type: int = RoutineType.STORE):
+    def do_routine(self, call_addr: int, args: tuple[int, ...], routine_type: int = RoutineType.STORE):
         store_varnum = 0
         if routine_type == RoutineType.STORE:
             store_varnum = self.read_from_pc()
@@ -358,7 +357,7 @@ class ZMachineInterpreter(AbstractZMachineInterpreter):
         if call_addr == 0:
             return True
         frame_id = self.call_stack.catch()
-        self.do_routine(call_addr, tuple[int](), RoutineType.DIRECT_CALL)
+        self.do_routine(call_addr, (), RoutineType.DIRECT_CALL)
         while self.call_stack.catch() > frame_id:
             self.run_instruction()
         if self.call_stack.catch() != frame_id:
@@ -497,7 +496,7 @@ class ZMachineInterpreter(AbstractZMachineInterpreter):
             text[i] = chr(self.read_byte(text_addr + start + i))
         # This is a version 5+ op, so encoded zscii strings will be 6 bytes.
         byte_len = 6
-        encoded = self.text_utils.zscii_encode(text, byte_len)
+        encoded = self.text_utils.zscii_encode(str.join('', text), byte_len)
         for i in range(byte_len):
             self.write_byte(coded_buffer + i, encoded[i])
 
@@ -540,7 +539,7 @@ class ZMachineInterpreter(AbstractZMachineInterpreter):
         self.pc = self.print_from_addr(self.pc, newline)
 
     def print_from_addr(self, addr, newline=False):
-        zchars = []
+        zchars: list[int] = []
         addr = self.text_utils.read_zchars(addr, zchars)
         text = self.text_utils.zscii_decode(zchars)
         self.write_to_output_streams(text, newline)

--- a/zmachine/memory.py
+++ b/zmachine/memory.py
@@ -1,6 +1,6 @@
-from error import IllegalWriteException
-from config import ZMachineConfig
-from constants import DEFAULT_BACKGROUND_COLOR, DEFAULT_FOREGROUND_COLOR
+from .error import IllegalWriteException
+from .config import ZMachineConfig
+from .constants import DEFAULT_BACKGROUND_COLOR, DEFAULT_FOREGROUND_COLOR
 
 class MemoryMap:
     def __init__(self, config: ZMachineConfig):
@@ -21,7 +21,7 @@ class MemoryMap:
             self.flags1_mask |= 1
         self.set_screen_flags()
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: int | slice):
         if isinstance(item, slice):
             return self._memory_map[item.start:item.stop:item.step]
         elif isinstance(item, int):
@@ -35,28 +35,28 @@ class MemoryMap:
             self._memory_map[key] = value
         raise Exception('Invalid type for array index')
 
-    def byte_addr(self, ptr):
+    def byte_addr(self, ptr: int) -> int:
         return self.read_word(ptr)
 
-    def word_addr(self, ptr):
+    def word_addr(self, ptr) -> int:
         return self.read_word(ptr) << 1
 
-    def unpack_addr(self, packed_addr):
+    def unpack_addr(self, packed_addr: int) -> int:
         shift = 1 if self._version <= 3 else 2
         return packed_addr << shift
 
-    def read_byte(self, addr):
+    def read_byte(self, addr: int) -> int:
         return self._memory_map[addr]
 
-    def read_word(self, addr):
+    def read_word(self, addr: int) -> int:
         return self._memory_map[addr] << 8 | self._memory_map[addr + 1]
 
-    def write_byte(self, addr, val):
+    def write_byte(self, addr: int, val: int):
         if addr >= self.config.static_memory_base_addr:
             raise IllegalWriteException(addr)
         self._memory_map[addr] = val & 0xff
 
-    def write_word(self, addr, val):
+    def write_word(self, addr: int, val: int):
         if addr + 1 >= self.config.static_memory_base_addr:
             raise IllegalWriteException(addr)
         self._memory_map[addr] = val >> 8 & 0xff

--- a/zmachine/object_table.py
+++ b/zmachine/object_table.py
@@ -1,5 +1,5 @@
-from memory import MemoryMap
-from error import *
+from .memory import MemoryMap
+from .error import *
 
 
 class ObjectTable:
@@ -16,22 +16,22 @@ class ObjectTable:
         self.SIBLING_OFFSET = 5 if self.version <= 3 else 8
         self.CHILD_OFFSET = 6 if self.version <= 3 else 10
 
-    def read_byte(self, addr):
+    def read_byte(self, addr: int) -> int:
         return self.memory_map.read_byte(addr)
 
-    def read_word(self, addr):
+    def read_word(self, addr: int) -> int:
         return self.memory_map.read_word(addr)
 
-    def byte_addr(self, addr):
+    def byte_addr(self, addr: int) -> int:
         return self.memory_map.byte_addr(addr)
 
-    def write_byte(self, addr, val):
+    def write_byte(self, addr: int, val: int):
         self.memory_map.write_byte(addr, val)
 
-    def write_word(self, addr, val):
+    def write_word(self, addr: int, val: int):
         self.memory_map.write_word(addr, val)
 
-    def get_obj_addr(self, obj_id):
+    def get_obj_addr(self, obj_id: int) -> int:
         if obj_id <= 0 or obj_id > self.MAX_OBJECTS:
             raise InvalidMemoryException(f"Object ID '{obj_id}' out of range")
         obj_addr = self.OBJECT_TABLE + \
@@ -45,7 +45,7 @@ class ObjectTable:
             obj_addr = 0
         return obj_addr
 
-    def get_attribute_flag(self, obj_id, attr_num) -> bool:
+    def get_attribute_flag(self, obj_id: int, attr_num: int) -> bool:
         if attr_num < 0 or attr_num >= self.ATTRIBUTE_FLAGS:
             raise InvalidArgumentException(f'Invalid attribute: {attr_num}')
         byte_offset = attr_num >> 3
@@ -68,7 +68,7 @@ class ObjectTable:
             attribute_byte &= (~attr_flag & 0xff)
         self.write_byte(obj_addr + byte_offset, attribute_byte)
 
-    def get_object_text_zchars(self, obj_id):
+    def get_object_text_zchars(self, obj_id: int) -> list[int]:
         obj_addr = self.get_obj_addr(obj_id)
         prop_header_addr = self.byte_addr(obj_addr + self.OBJECT_BYTES - 2)
         word_count = self.read_byte(prop_header_addr)

--- a/zmachine/opcodes.py
+++ b/zmachine/opcodes.py
@@ -2,9 +2,9 @@ import random
 import time
 from typing import Callable, Dict, Any
 from functools import wraps
-from abstract_interpreter import AbstractZMachineInterpreter
-from enums import RoutineType
-from error import *
+from .abstract_interpreter import AbstractZMachineInterpreter
+from .enums import RoutineType
+from .error import *
 
 
 def get_opcodes(version: int) -> Dict[int, Callable[[AbstractZMachineInterpreter, *tuple[int, ...]], Any]]:

--- a/zmachine/output.py
+++ b/zmachine/output.py
@@ -1,8 +1,9 @@
-from memory import MemoryMap
-from screen import BaseScreen
-from event import EventManager, EventArgs
-from enums import WindowPosition, OutputStreamType
-from error import StreamException
+from .config import ZMachineConfig
+from .memory import MemoryMap
+from .screen import BaseScreen
+from .event import EventManager, EventArgs
+from .enums import WindowPosition, OutputStreamType
+from .error import StreamException
 import os
 
 
@@ -93,13 +94,13 @@ class TranscriptStream(OutputStream):
 
     def __init__(self, memory_map: MemoryMap, event_manager: EventManager):
         super().__init__()
-        self.config = memory_map.config
-        self.event_manager = event_manager
-        self.buffer = ['\0'] * self._BUFFER_LENGTH
-        self.buffer_ptr = 0
-        self.script_full_path = None
-        self.script_file_mode = 'w'
-        self.transcript_full_path = None
+        self.config: ZMachineConfig = memory_map.config
+        self.event_manager: EventManager = event_manager
+        self.buffer: list[str] = ['\0'] * self._BUFFER_LENGTH
+        self.buffer_ptr: int = 0
+        self.script_full_path: str | None = None
+        self.script_file_mode: str = 'w'
+        self.transcript_full_path: str | None = None
         self.memory_map = memory_map
 
     def open(self, **kwargs):
@@ -229,7 +230,7 @@ class MemoryStream(OutputStream):
 class RecordStream(OutputStream):
     def __init__(self):
         super().__init__()
-        self.record_full_path = None
+        self.record_full_path = ''
 
     def register_delegates(self, event_manager: EventManager):
         event_manager.post_read_input += self.post_read_input_handler

--- a/zmachine/quetzal.py
+++ b/zmachine/quetzal.py
@@ -1,10 +1,10 @@
 import os
 from enum import Enum
 from typing import BinaryIO, Callable, Any
-from event import EventArgs, EventManager
-from memory import MemoryMap
-from constants import IFF_HEADER, IFZS_ID
-from stack import CallStack
+from .event import EventArgs, EventManager
+from .memory import MemoryMap
+from .constants import IFF_HEADER, IFZS_ID
+from .stack import CallStack
 
 class IffType(Enum):
     HEADER = 'IFhd'
@@ -72,7 +72,7 @@ class Quetzal:
         save_full_path = os.path.join(filepath, save_file)
         if not os.path.exists(save_full_path):
             return False
-        chunks = {}
+        chunks: dict[str, IffChunk] = {}
         with open(save_full_path, 'rb') as s:
             header = s.read(4)
             data_len = int.from_bytes(s.read(4), "big")

--- a/zmachine/screen.py
+++ b/zmachine/screen.py
@@ -1,8 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Callable
-from event import EventManager, EventArgs
-from enums import WindowPosition, TextStyle
-from constants import DEFAULT_BACKGROUND_COLOR, DEFAULT_FOREGROUND_COLOR
+from .event import EventManager, EventArgs
+from .enums import WindowPosition, TextStyle
+from .constants import DEFAULT_BACKGROUND_COLOR, DEFAULT_FOREGROUND_COLOR
 
 
 class Window:
@@ -152,24 +152,6 @@ class BaseScreen:
         self.reset_output_line_count()
         self.flush_buffer(self.active_window)
         self.terminal_adapter.refresh()
-
-    def read_input_handler(self, sender, event_args: EventArgs):
-        timeout_ms: int = event_args.timeout_ms
-        text_buffer: list[int] = event_args.text_buffer
-        interrupt_routine_caller: Callable[[int], int] = event_args.interrupt_routine_caller
-        interrupt_routine_addr: int = event_args.interrupt_routine_addr
-        echo = event_args.get('echo', True)
-        self.terminal_adapter.read_keyboard_input(
-            text_buffer,
-            timeout_ms,
-            interrupt_routine_caller,
-            interrupt_routine_addr,
-            echo
-        )
-        if echo:
-            buffer_len = text_buffer.index(0)
-            if buffer_len > 0 and text_buffer[buffer_len - 1] == 13:
-                self.output_line_count = 0
 
     def set_window_handler(self, sender, e: EventArgs):
         window_id = e.window_id

--- a/zmachine/stack.py
+++ b/zmachine/stack.py
@@ -1,16 +1,16 @@
-from enums import RoutineType
-from constants import MAX_STACK_LENGTH
+from .enums import RoutineType
+from .constants import MAX_STACK_LENGTH
 from typing import List
 
 
 class StackFrame:
     def __init__(self, **kwargs):
-        self.local_vars = []
-        self.eval_stack = EvalStack()
-        self.return_pc = 0
-        self.store_varnum = 0
-        self.arg_count = 0
-        self.routine_type = RoutineType.STORE
+        self.local_vars: list[int] = []
+        self.eval_stack: EvalStack = EvalStack()
+        self.return_pc: int = 0
+        self.store_varnum: int = 0
+        self.arg_count: int = 0
+        self.routine_type: RoutineType = RoutineType.STORE
         for attr, val in kwargs.items():
             setattr(self, attr, val)
 
@@ -30,13 +30,13 @@ class CallStack:
             self.frame_ptr = 1
 
     @property
-    def current_frame(self):
+    def current_frame(self) -> 'StackFrame':
         if self.frame_ptr <= 0:
             raise Exception('No current call frame')
         return self.frames[self.frame_ptr - 1]
 
     @property
-    def eval_stack(self):
+    def eval_stack(self) -> 'EvalStack':
         return self.current_frame.eval_stack
 
     def push(self, **kwargs):
@@ -57,7 +57,7 @@ class CallStack:
         self.frame_ptr = 1 if self.has_dummy_frame else 0
         self.eval_stack.clear()
 
-    def get_local_var(self, index) -> int:
+    def get_local_var(self, index: int) -> int:
         local_vars = self.current_frame.local_vars
         if index >= len(local_vars):
             raise Exception('Invalid index for local variable')
@@ -108,7 +108,7 @@ class CallStack:
             result.extend(frame_bytes)
         return result
 
-    def deserialize(self, data: bytearray):
+    def deserialize(self, data: bytes):
         frame_index = 0
         data_ptr = 0
         while data_ptr < len(data):
@@ -152,11 +152,10 @@ class CallStack:
 
 
 class EvalStack:
-    def __init__(self, items: List[int] = None):
+    def __init__(self, items: List[int] = []):
         self.stack: List[int] = []
         self.sp: int = 0
-        if items is not None:
-            self.set_items(items)
+        self.set_items(items)
 
     def push(self, value: int):
         if self.sp >= MAX_STACK_LENGTH:

--- a/zmachine/text.py
+++ b/zmachine/text.py
@@ -1,6 +1,6 @@
-from memory import MemoryMap
+from .memory import MemoryMap
 from typing import List
-from error import *
+from .error import *
 
 
 class TextUtils:
@@ -109,7 +109,7 @@ class TextUtils:
             positions += [pos]
         return tokens, positions
 
-    def zscii_decode(self, zchars):
+    def zscii_decode(self, zchars: list[int]) -> str:
         result = []
         current_alphabet = self.A0
         zptr = 0
@@ -158,13 +158,13 @@ class TextUtils:
             addr += 2
         return addr
 
-    def abbreviation_lookup(self, index):
-        result = []
+    def abbreviation_lookup(self, index: int) -> list[int]:
+        result: list[int] = []
         addr = self.memory_map.word_addr(self.config.abbreviation_table_addr + index * 2)
         self.read_zchars(addr, result)
         return result
 
-    def zscii_encode(self, text, byte_len=4) -> list[int]:
+    def zscii_encode(self, text: str, byte_len: int = 4) -> list[int]:
         zlen = byte_len // 2 * 3
         zchars = []
         for c in text:

--- a/zmachine/undo.py
+++ b/zmachine/undo.py
@@ -14,7 +14,7 @@ class UndoFrame:
         return result
 
     @classmethod
-    def deserialize(cls, data: bytearray):
+    def deserialize(cls, data: bytearray) -> "UndoFrame":
         dynamic_memory_len = int.from_bytes(data[:4], "big")
         data_ptr = dynamic_memory_len + 4
         dynamic_memory = data[4:data_ptr]


### PR DESCRIPTION
- Add mypy configuration in pyproject.toml with strict checks enabled
- Convert 65 implicit imports to explicit relative imports (PEP 8)
- Fix tuple type annotations: tuple[int] → tuple[int, ...] for variable-length
- Add null checks for regex matches in PlaybackInputStream
- Add bool() casts for EventArgs attributes returning Any
- Simplify CursesAdapter initialization to avoid Optional types